### PR TITLE
Use BlockUpdateEvent Instead

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: OreSpawners
-version: 0.1
+version: 0.2
 main: RKAbdul\OreSpawners\Main
 api: 3.0.0
 


### PR DESCRIPTION
Use BlockUpdateEvent instead so that the plugin will be compatible with plugins that use setBlock() to remove the ores. A plugin like the Minions plugin by CLADevs will be compatible after this change.